### PR TITLE
Add more functions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
         -   `export LDFLAGS="-L/opt/homebrew/opt/openssl@3/lib"`
         -   `export CPPFLAGS="-I/opt/homebrew/opt/openssl@3/include"`
 
+    - For Linux users, check [here](https://linuxhint.com/install-openssl-3-from-source/) for installation. 
+
 # Code Hiearchy
 
 c_common -> c_crypto -> c_secure_comm -> c_api -> entity_client, entity_server

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ pthread_create(&thread, NULL, &receive_thread, (void \*)session_ctx);
 
 -   Enables receiving messages.
 
+**unsigned char * return_decrypted_buf()**
+
+-   Returns the buffer of the decrypted buffer.
+
 **void send_secure_message()**
 
 -   `secure send_secure_message()` is a function that send a message with secure communication to the server by encrypting it with the session key.

--- a/c_api.c
+++ b/c_api.c
@@ -248,7 +248,7 @@ void receive_message(unsigned char *received_buf,
     unsigned char *data_buf = parse_received_message(
         received_buf, received_buf_length, &message_type, &data_buf_length);
     if (message_type == SECURE_COMM_MSG) {
-        print_recevied_message(data_buf, data_buf_length, session_ctx);
+        print_received_message(data_buf, data_buf_length, session_ctx);
     }
 }
 

--- a/c_api.c
+++ b/c_api.c
@@ -246,7 +246,9 @@ void *receive_thread_read_one_each(void *SST_session_ctx) {
     unsigned int data_buf_length = 0;
     while (1) {
         unsigned char message_type;
-        if(1 != read_header_return_data_buf_pointer(session_ctx->sock, &message_type, data_buf, &data_buf_length)){
+        if (1 != read_header_return_data_buf_pointer(session_ctx->sock,
+                                                     &message_type, data_buf,
+                                                     &data_buf_length)) {
             return 0;
         }
         if (message_type == SECURE_COMM_MSG) {

--- a/c_api.c
+++ b/c_api.c
@@ -115,7 +115,8 @@ SST_session_ctx_t *server_secure_comm_setup(
 
     if (entity_server_state == IDLE) {
         unsigned char received_buf[MAX_HS_BUF_LENGTH];
-        int received_buf_length = read(clnt_sock, received_buf, HANDSHAKE_1_LENGTH);
+        int received_buf_length =
+            read(clnt_sock, received_buf, HANDSHAKE_1_LENGTH);
         unsigned char message_type;
         unsigned int data_buf_length;
         unsigned char *data_buf = parse_received_message(
@@ -180,7 +181,8 @@ SST_session_ctx_t *server_secure_comm_setup(
     }
     if (entity_server_state == HANDSHAKE_2_SENT) {
         unsigned char received_buf[MAX_HS_BUF_LENGTH];
-        int received_buf_length = read(clnt_sock, received_buf, HANDSHAKE_3_LENGTH);
+        int received_buf_length =
+            read(clnt_sock, received_buf, HANDSHAKE_3_LENGTH);
         unsigned char message_type;
         unsigned int data_buf_length;
         unsigned char *data_buf = parse_received_message(
@@ -247,6 +249,18 @@ void receive_message(unsigned char *received_buf,
         received_buf, received_buf_length, &message_type, &data_buf_length);
     if (message_type == SECURE_COMM_MSG) {
         print_recevied_message(data_buf, data_buf_length, session_ctx);
+    }
+}
+
+unsigned char * return_decrypted_buf(unsigned char *received_buf,
+                                   unsigned int received_buf_length,
+                                   SST_session_ctx_t *session_ctx) {
+    unsigned char message_type;
+    unsigned int data_buf_length;
+    unsigned char *data_buf = parse_received_message(
+        received_buf, received_buf_length, &message_type, &data_buf_length);
+    if (message_type == SECURE_COMM_MSG) {
+        return decrypt_received_message(data_buf, data_buf_length, session_ctx);
     }
 }
 

--- a/c_api.c
+++ b/c_api.c
@@ -77,7 +77,7 @@ SST_session_ctx_t *secure_connect_to_server(session_key_t *s_key,
         received_buf, received_buf_length, &message_type, &data_buf_length);
     if (message_type == SKEY_HANDSHAKE_2) {
         if (entity_client_state != HANDSHAKE_1_SENT) {
-            printf(
+            error_handling(
                 "Comm init failed: wrong sequence of handshake, "
                 "disconnecting...\n");
         }
@@ -237,6 +237,21 @@ void *receive_thread(void *SST_session_ctx) {
             return 0;
         }
         receive_message(received_buf, received_buf_length, session_ctx);
+    }
+}
+
+void *receive_thread_read_one_each(void *SST_session_ctx) {
+    SST_session_ctx_t *session_ctx = (SST_session_ctx_t *)SST_session_ctx;
+    unsigned char data_buf[MAX_PAYLOAD_LENGTH];
+    unsigned int data_buf_length = 0;
+    while (1) {
+        unsigned char message_type;
+        if(1 != read_header_return_data_buf_pointer(session_ctx->sock, &message_type, data_buf, &data_buf_length)){
+            return 0;
+        }
+        if (message_type == SECURE_COMM_MSG) {
+            print_received_message(data_buf, data_buf_length, session_ctx);
+        }
     }
 }
 

--- a/c_api.c
+++ b/c_api.c
@@ -252,9 +252,9 @@ void receive_message(unsigned char *received_buf,
     }
 }
 
-unsigned char * return_decrypted_buf(unsigned char *received_buf,
-                                   unsigned int received_buf_length,
-                                   SST_session_ctx_t *session_ctx) {
+unsigned char *return_decrypted_buf(unsigned char *received_buf,
+                                    unsigned int received_buf_length,
+                                    SST_session_ctx_t *session_ctx) {
     unsigned char message_type;
     unsigned int data_buf_length;
     unsigned char *data_buf = parse_received_message(

--- a/c_api.h
+++ b/c_api.h
@@ -38,8 +38,8 @@ SST_session_ctx_t *server_secure_comm_setup(
 // @param arguments struct including session key and socket number
 void *receive_thread(void *SST_session_ctx);
 
-// Creates a thread to receive messages, by reading one bytes each at the SST header.
-// Max buffer length is 1000 bytes currently.
+// Creates a thread to receive messages, by reading one bytes each at the SST
+// header. Max buffer length is 1000 bytes currently.
 // @param arguments struct including session key and socket number
 void *receive_thread_read_one_each(void *SST_session_ctx);
 

--- a/c_api.h
+++ b/c_api.h
@@ -47,21 +47,22 @@ void receive_message(unsigned char *received_buf,
                      SST_session_ctx_t *session_ctx);
 
 // Return the buffer pointer of the decrypted buffer.
-// If the user gives the read buffer as input, it will return the decrypted buffer.
+// If the user gives the read buffer as input, it will return the decrypted
+// buffer.
 // @param received_buf received message buffer
 // @param received_buf_length length of received_buf
 // @param SST_session_ctx_t session ctx struct
 unsigned char *return_decrypted_buf(unsigned char *received_buf,
                                     unsigned int received_buf_length,
-                                    SST_session_ctx_t *session_ctx)
+                                    SST_session_ctx_t *session_ctx);
 
-    // Encrypt the message with session key and send the encrypted message to
-    // the socket.
-    // @param msg message to send
-    // @param msg_length length of message
-    // @param SST_session_ctx_t session ctx struct
-    void send_secure_message(char *msg, unsigned int msg_length,
-                             SST_session_ctx_t *session_ctx);
+// Encrypt the message with session key and send the encrypted message to
+// the socket.
+// @param msg message to send
+// @param msg_length length of message
+// @param SST_session_ctx_t session ctx struct
+void send_secure_message(char *msg, unsigned int msg_length,
+                         SST_session_ctx_t *session_ctx);
 
 // Frees memory used in session_key_list recursively.
 // @param session_key_list_t session_key_list to free

--- a/c_api.h
+++ b/c_api.h
@@ -46,13 +46,22 @@ void receive_message(unsigned char *received_buf,
                      unsigned int received_buf_length,
                      SST_session_ctx_t *session_ctx);
 
-// Encrypt the message with session key and send the encrypted message to the
-// socket.
-// @param msg message to send
-// @param msg_length length of message
+// Return the buffer pointer of the decrypted buffer.
+// If the user gives the read buffer as input, it will return the decrypted buffer.
+// @param received_buf received message buffer
+// @param received_buf_length length of received_buf
 // @param SST_session_ctx_t session ctx struct
-void send_secure_message(char *msg, unsigned int msg_length,
-                         SST_session_ctx_t *session_ctx);
+unsigned char *return_decrypted_buf(unsigned char *received_buf,
+                                    unsigned int received_buf_length,
+                                    SST_session_ctx_t *session_ctx)
+
+    // Encrypt the message with session key and send the encrypted message to
+    // the socket.
+    // @param msg message to send
+    // @param msg_length length of message
+    // @param SST_session_ctx_t session ctx struct
+    void send_secure_message(char *msg, unsigned int msg_length,
+                             SST_session_ctx_t *session_ctx);
 
 // Frees memory used in session_key_list recursively.
 // @param session_key_list_t session_key_list to free

--- a/c_api.h
+++ b/c_api.h
@@ -38,6 +38,11 @@ SST_session_ctx_t *server_secure_comm_setup(
 // @param arguments struct including session key and socket number
 void *receive_thread(void *SST_session_ctx);
 
+// Creates a thread to receive messages, by reading one bytes each at the SST header.
+// Max buffer length is 1000 bytes currently.
+// @param arguments struct including session key and socket number
+void *receive_thread_read_one_each(void *SST_session_ctx);
+
 // Receive the message and print the message after decrypting with session key.
 // @param received_buf received message buffer
 // @param received_buf_length length of received_buf

--- a/c_common.c
+++ b/c_common.c
@@ -90,12 +90,21 @@ uint16_t read_variable_length_one_byte_each(int socket, unsigned char *buf) {
     }
 }
 
-void read_header_return_data_buf_pointer(int socket,
+int read_header_return_data_buf_pointer(int socket,
                                          unsigned char *message_type,
                                          unsigned char *ret,
                                          unsigned int *ret_length) {
     unsigned char received_buf[MAX_PAYLOAD_BUF_SIZE];
-    read(socket, received_buf, MESSAGE_TYPE_SIZE);
+    int socket_read = read(socket, received_buf, MESSAGE_TYPE_SIZE);
+    if (socket_read == 0) {
+        printf("Socket closed!\n");
+        close(socket);
+        return 0;
+    }
+    if (socket_read == -1) {
+        printf("Connection error!\n");
+        return 0;
+    }
     *message_type = received_buf[0];
     uint16_t var_length_buf_size = read_variable_length_one_byte_each(
         socket, received_buf + MESSAGE_TYPE_SIZE);
@@ -106,6 +115,7 @@ void read_header_return_data_buf_pointer(int socket,
         error_handling("Wrong header calculation... Exiting...");
     }
     read(socket, ret, *ret_length);
+    return 1;
 }
 
 void make_buffer_header(unsigned int data_length, unsigned char MESSAGE_TYPE,

--- a/c_common.c
+++ b/c_common.c
@@ -90,10 +90,9 @@ uint16_t read_variable_length_one_byte_each(int socket, unsigned char *buf) {
     }
 }
 
-int read_header_return_data_buf_pointer(int socket,
-                                         unsigned char *message_type,
-                                         unsigned char *ret,
-                                         unsigned int *ret_length) {
+int read_header_return_data_buf_pointer(int socket, unsigned char *message_type,
+                                        unsigned char *ret,
+                                        unsigned int *ret_length) {
     unsigned char received_buf[MAX_PAYLOAD_BUF_SIZE];
     int socket_read = read(socket, received_buf, MESSAGE_TYPE_SIZE);
     if (socket_read == 0) {

--- a/c_common.h
+++ b/c_common.h
@@ -144,7 +144,7 @@ uint16_t read_variable_length_one_byte_each(int socket, unsigned char *buf);
 // @param message_type SST message type
 // @param ret Return buffer
 // @param ret_length Return buffer's length
-void read_header_return_data_buf_pointer(int socket,
+int read_header_return_data_buf_pointer(int socket,
                                          unsigned char *message_type,
                                          unsigned char *ret,
                                          unsigned int *ret_length);

--- a/c_common.h
+++ b/c_common.h
@@ -94,8 +94,7 @@ void write_in_n_bytes(uint64_t num, int n, unsigned char *buf);
 // @return total number of input buffer
 unsigned int read_unsigned_int_BE(unsigned char *buf, int byte_length);
 
-uint64_t read_unsigned_long_int_BE(unsigned char *buf,
-                                            int byte_length);
+uint64_t read_unsigned_long_int_BE(unsigned char *buf, int byte_length);
 
 // Extracts number value of variable length integer from given buffer.
 // When
@@ -109,8 +108,7 @@ uint64_t read_unsigned_long_int_BE(unsigned char *buf,
 //  @param var_len_int_buf_size size of the buffer containing the variable
 //  length integer
 void var_length_int_to_num(unsigned char *buf, unsigned int buf_length,
-                           unsigned int *num,
-                           unsigned int *var_len_int_buf_size);
+                           unsigned int *num, uint16_t *var_len_int_buf_size);
 
 // Make the data_length to a variable length.
 // @param num number to be converted into variable length integer.
@@ -118,7 +116,7 @@ void var_length_int_to_num(unsigned char *buf, unsigned int buf_length,
 // @param var_len_int_buf_size size of the buffer containing the variable
 // length integer.
 void num_to_var_length_int(unsigned int num, unsigned char *var_len_int_buf,
-                           unsigned int *var_len_int_buf_size);
+                           uint16_t *var_len_int_buf_size);
 
 // Parses received message into 'message_type',
 // and data after msg_type+payload_buf to 'data_buf'.
@@ -133,6 +131,23 @@ unsigned char *parse_received_message(unsigned char *received_buf,
                                       unsigned int received_buf_length,
                                       unsigned char *message_type,
                                       unsigned int *data_buf_length);
+
+// Reads the variable length one byte each. The read() function reads one byte
+// each, and returns the variable length buffer's size.
+// @param socket socket to read
+// @param buf buffer to save the result of read() function.
+uint16_t read_variable_length_one_byte_each(int socket, unsigned char *buf);
+
+// Reads the SST header, and returns the message type, start pointer of the
+// SST's payload, and the payload's length.
+// @param socket socket to read
+// @param message_type SST message type
+// @param ret Return buffer
+// @param ret_length Return buffer's length
+void read_header_return_data_buf_pointer(int socket,
+                                         unsigned char *message_type,
+                                         unsigned char *ret,
+                                         unsigned int *ret_length);
 
 // Makes sender_buf with 'payload' and 'MESSAGE_TYPE' to 'sender'.
 // The four functions num_to_var_length_int(), make_buffer_header(),

--- a/c_common.h
+++ b/c_common.h
@@ -144,10 +144,9 @@ uint16_t read_variable_length_one_byte_each(int socket, unsigned char *buf);
 // @param message_type SST message type
 // @param ret Return buffer
 // @param ret_length Return buffer's length
-int read_header_return_data_buf_pointer(int socket,
-                                         unsigned char *message_type,
-                                         unsigned char *ret,
-                                         unsigned int *ret_length);
+int read_header_return_data_buf_pointer(int socket, unsigned char *message_type,
+                                        unsigned char *ret,
+                                        unsigned int *ret_length);
 
 // Makes sender_buf with 'payload' and 'MESSAGE_TYPE' to 'sender'.
 // The four functions num_to_var_length_int(), make_buffer_header(),

--- a/c_secure_comm.c
+++ b/c_secure_comm.c
@@ -231,27 +231,7 @@ unsigned char *check_handshake_2_send_handshake_3(unsigned char *data_buf,
     return ret;
 }
 
-void print_recevied_message(unsigned char *data, unsigned int data_length,
-                            SST_session_ctx_t *session_ctx) {
-    unsigned int decrypted_length;
-    unsigned char *decrypted = symmetric_decrypt_authenticate(
-        data, data_length, session_ctx->s_key.mac_key, MAC_KEY_SIZE,
-        session_ctx->s_key.cipher_key, CIPHER_KEY_SIZE, AES_CBC_128_IV_SIZE,
-        &decrypted_length);
-    unsigned int received_seq_num =
-        read_unsigned_int_BE(decrypted, SEQ_NUM_SIZE);
-    if (received_seq_num != session_ctx->received_seq_num) {
-        error_handling("Wrong sequence number expected.");
-    }
-    if (check_session_key_validity(&session_ctx->s_key)) {
-        error_handling("Session key expired!\n");
-    }
-    session_ctx->received_seq_num++;
-    printf("Received seq_num: %d\n", received_seq_num);
-    printf("%s\n", decrypted + SEQ_NUM_SIZE);
-}
-
-void print_recevied_message(unsigned char *data, unsigned int data_length,
+void print_received_message(unsigned char *data, unsigned int data_length,
                             SST_session_ctx_t *session_ctx) {
     unsigned char * decrypted = decrypt_received_message(data, data_length, session_ctx);                            
     printf("%s\n", decrypted + SEQ_NUM_SIZE);

--- a/c_secure_comm.c
+++ b/c_secure_comm.c
@@ -233,12 +233,14 @@ unsigned char *check_handshake_2_send_handshake_3(unsigned char *data_buf,
 
 void print_received_message(unsigned char *data, unsigned int data_length,
                             SST_session_ctx_t *session_ctx) {
-    unsigned char * decrypted = decrypt_received_message(data, data_length, session_ctx);                            
+    unsigned char *decrypted =
+        decrypt_received_message(data, data_length, session_ctx);
     printf("%s\n", decrypted + SEQ_NUM_SIZE);
 }
 
-unsigned char * decrypt_received_message(unsigned char *data, unsigned int data_length,
-                              SST_session_ctx_t *session_ctx) {
+unsigned char *decrypt_received_message(unsigned char *data,
+                                        unsigned int data_length,
+                                        SST_session_ctx_t *session_ctx) {
     unsigned int decrypted_length;
     unsigned char *decrypted = symmetric_decrypt_authenticate(
         data, data_length, session_ctx->s_key.mac_key, MAC_KEY_SIZE,

--- a/c_secure_comm.c
+++ b/c_secure_comm.c
@@ -251,6 +251,32 @@ void print_recevied_message(unsigned char *data, unsigned int data_length,
     printf("%s\n", decrypted + SEQ_NUM_SIZE);
 }
 
+void print_recevied_message(unsigned char *data, unsigned int data_length,
+                            SST_session_ctx_t *session_ctx) {
+    unsigned char * decrypted = decrypt_received_message(data, data_length, session_ctx);                            
+    printf("%s\n", decrypted + SEQ_NUM_SIZE);
+}
+
+unsigned char * decrypt_received_message(unsigned char *data, unsigned int data_length,
+                              SST_session_ctx_t *session_ctx) {
+    unsigned int decrypted_length;
+    unsigned char *decrypted = symmetric_decrypt_authenticate(
+        data, data_length, session_ctx->s_key.mac_key, MAC_KEY_SIZE,
+        session_ctx->s_key.cipher_key, CIPHER_KEY_SIZE, AES_CBC_128_IV_SIZE,
+        &decrypted_length);
+    unsigned int received_seq_num =
+        read_unsigned_int_BE(decrypted, SEQ_NUM_SIZE);
+    if (received_seq_num != session_ctx->received_seq_num) {
+        error_handling("Wrong sequence number expected.");
+    }
+    if (check_session_key_validity(&session_ctx->s_key)) {
+        error_handling("Session key expired!\n");
+    }
+    session_ctx->received_seq_num++;
+    printf("Received seq_num: %d\n", received_seq_num);
+    return decrypted;
+}
+
 int check_session_key_validity(session_key_t *session_key) {
     return check_validity(session_key->abs_validity);
 }

--- a/c_secure_comm.h
+++ b/c_secure_comm.h
@@ -15,7 +15,7 @@
 #define IN_COMM 30
 #define SESSION_KEY_EXPIRATION_TIME_SIZE 6
 #define HANDSHAKE_1_LENGTH 74
-#define HANDSHAKE_3_LENGTH 82 
+#define HANDSHAKE_3_LENGTH 82
 
 #define MAX_SESSION_KEY 10
 
@@ -163,6 +163,15 @@ unsigned char *check_handshake_2_send_handshake_3(unsigned char *data_buf,
 // @param SST_session_ctx_t session ctx struct
 void print_recevied_message(unsigned char *data, unsigned int data_length,
                             SST_session_ctx_t *session_ctx);
+
+// Returns the pointer of the decrypted buffer.
+// @param data input data buffer
+// @param data_length length of data buffer
+// @param SST_session_ctx_t session ctx struct
+
+unsigned char *decrypt_received_message(unsigned char *data,
+                                        unsigned int data_length,
+                                        SST_session_ctx_t *session_ctx);
 
 // Check the validity of session key by checking abs_validity
 // @param session_key_t session_key to check validity

--- a/c_secure_comm.h
+++ b/c_secure_comm.h
@@ -161,7 +161,7 @@ unsigned char *check_handshake_2_send_handshake_3(unsigned char *data_buf,
 // @param data input data buffer
 // @param data_length length of data buffer
 // @param SST_session_ctx_t session ctx struct
-void print_recevied_message(unsigned char *data, unsigned int data_length,
+void print_received_message(unsigned char *data, unsigned int data_length,
                             SST_session_ctx_t *session_ctx);
 
 // Returns the pointer of the decrypted buffer.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 3.19)
 project(SST VERSION 1.0.0 LANGUAGES C)
 
+# Check `openssl version -d` and copy the path to OPENSSL_ROOT_DIR
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+    set(OPENSSL_ROOT_DIR "/usr/local/ssl")
+endif()
+
 find_package(OpenSSL REQUIRED)
 find_package(Threads REQUIRED)
 

--- a/examples/entity_client.c
+++ b/examples/entity_client.c
@@ -10,7 +10,7 @@ int main(int argc, char *argv[]) {
     printf("finished\n");
     sleep(1); 
     pthread_t thread;
-    pthread_create(&thread, NULL, &receive_thread, (void *)session_ctx);
+    pthread_create(&thread, NULL, &receive_thread_read_one_each, (void *)session_ctx);
     send_secure_message("Hello server", strlen("Hello server"), session_ctx);
     sleep(1);
     send_secure_message("Hello server - second message", strlen("Hello server - second message"), session_ctx);
@@ -26,7 +26,7 @@ int main(int argc, char *argv[]) {
     pthread_t thread2;
     session_ctx =
         secure_connect_to_server(&s_key_list->s_key[1], ctx);
-    pthread_create(&thread2, NULL, &receive_thread, (void *)session_ctx);
+    pthread_create(&thread2, NULL, &receive_thread_read_one_each, (void *)session_ctx);
     send_secure_message("Hello server 2", strlen("Hello server 2"), session_ctx);
     sleep(1);
     send_secure_message("Hello server 2 - second message", strlen("Hello server 2 - second message"), session_ctx);

--- a/examples/entity_server.c
+++ b/examples/entity_server.c
@@ -47,7 +47,7 @@ int main(int argc, char *argv[]) {
         server_secure_comm_setup(ctx, clnt_sock, &s_key_list);
 
     pthread_t thread;
-    pthread_create(&thread, NULL, &receive_thread, (void *)session_ctx);
+    pthread_create(&thread, NULL, &receive_thread_read_one_each, (void *)session_ctx);
     sleep(1);
 
     send_secure_message("Hello client", strlen("Hello client"), session_ctx);
@@ -68,7 +68,7 @@ int main(int argc, char *argv[]) {
         server_secure_comm_setup(ctx, clnt_sock2, &s_key_list);
 
     pthread_t thread2;
-    pthread_create(&thread2, NULL, &receive_thread, (void *)session_ctx2);
+    pthread_create(&thread2, NULL, &receive_thread_read_one_each, (void *)session_ctx2);
     sleep(1);
 
     send_secure_message("Hello client 2", strlen("Hello client 2"), session_ctx2);


### PR DESCRIPTION
# Added functions #
## 1. ```return_decrypted_buf()``` ##
Returns the buffer pointer of the decrypted buffer.
If the user gives the read buffer as input, it will return the decrypted buffer.

## 2. ```receive_thread_read_one_each()``` ##
Creates a thread to receive messages, by reading one bytes each at the SST header.

### 2-1. ```read_header_return_data_buf_pointer()``` ###
Reads the SST header, and returns the message type, start pointer of the SST's payload, and the payload's length.

### 2-2. ```read_variable_length_one_byte_each()``` ###
Reads the variable length header recursively one byte each. The ```read()``` function reads one byte each, and returns the variable length buffer's size.

These APIs are for reading one byte each and parsing the data buffer. The ```parse_received_message()``` function does this in once, but the new functions are used when reading one byte each is needed.

# Fix multiple typos and formatting. #

Multiply typos and formatting has been updated.