### PR TITLE
[Draft] Refactoring.

### DIFF
--- a/c_api.c
+++ b/c_api.c
@@ -98,7 +98,7 @@ SST_session_ctx_t *secure_connect_to_server_with_socket(session_key_t *s_key,
     make_sender_buf(parsed_buf, parsed_buf_length, SKEY_HANDSHAKE_1,
                     sender_HS_1, &sender_HS_1_length);
     unsigned int bytes_written =
-        write_to_socket(sock, sender_HS_1, sender_HS_1_length);
+        sst_write_to_socket(sock, sender_HS_1, sender_HS_1_length);
     if (bytes_written != sender_HS_1_length) {
         error_exit("Failed to write data to socket.");
     }
@@ -108,7 +108,7 @@ SST_session_ctx_t *secure_connect_to_server_with_socket(session_key_t *s_key,
     // received handshake 2
     unsigned char received_buf[MAX_HS_BUF_LENGTH];
     unsigned int received_buf_length =
-        read_from_socket(sock, received_buf, sizeof(received_buf));
+        sst_read_from_socket(sock, received_buf, sizeof(received_buf));
     unsigned char message_type;
     unsigned int data_buf_length;
     unsigned char *data_buf = parse_received_message(
@@ -127,7 +127,7 @@ SST_session_ctx_t *secure_connect_to_server_with_socket(session_key_t *s_key,
         make_sender_buf(parsed_buf, parsed_buf_length, SKEY_HANDSHAKE_3,
                         sender_HS_2, &sender_HS_2_length);
         unsigned int bytes_written =
-            write_to_socket(sock, sender_HS_2, sender_HS_2_length);
+            sst_write_to_socket(sock, sender_HS_2, sender_HS_2_length);
         if (bytes_written != sender_HS_2_length) {
             error_exit("Failed to write data to socket.");
         }
@@ -197,7 +197,7 @@ SST_session_ctx_t *server_secure_comm_setup(
     if (entity_server_state == IDLE) {
         unsigned char received_buf[MAX_HS_BUF_LENGTH];
         int received_buf_length =
-            read_from_socket(clnt_sock, received_buf, HANDSHAKE_1_LENGTH);
+            sst_read_from_socket(clnt_sock, received_buf, HANDSHAKE_1_LENGTH);
         if (received_buf_length < 0) {
             perror("Read Error:");
         }
@@ -237,7 +237,7 @@ SST_session_ctx_t *server_secure_comm_setup(
             make_sender_buf(parsed_buf, parsed_buf_length, SKEY_HANDSHAKE_2,
                             sender, &sender_length);
             unsigned int bytes_written =
-                write_to_socket(clnt_sock, sender, sender_length);
+                sst_write_to_socket(clnt_sock, sender, sender_length);
             if (bytes_written != sender_length) {
                 error_exit("Failed to write data to socket.");
             }
@@ -249,7 +249,7 @@ SST_session_ctx_t *server_secure_comm_setup(
     if (entity_server_state == HANDSHAKE_2_SENT) {
         unsigned char received_buf[MAX_HS_BUF_LENGTH];
         unsigned int received_buf_length =
-            read_from_socket(clnt_sock, received_buf, HANDSHAKE_3_LENGTH);
+            sst_read_from_socket(clnt_sock, received_buf, HANDSHAKE_3_LENGTH);
         unsigned char message_type;
         unsigned int data_buf_length;
         unsigned char *data_buf = parse_received_message(
@@ -298,7 +298,7 @@ void *receive_thread(void *SST_session_ctx) {
     unsigned char received_buf[MAX_PAYLOAD_LENGTH];
     unsigned int received_buf_length;
     while (1) {
-        received_buf_length = read_from_socket(session_ctx->sock, received_buf,
+        received_buf_length = sst_read_from_socket(session_ctx->sock, received_buf,
                                                sizeof(received_buf));
         receive_message(received_buf, received_buf_length, session_ctx);
     }

--- a/c_common.c
+++ b/c_common.c
@@ -92,7 +92,7 @@ unsigned char *parse_received_message(unsigned char *received_buf,
 
 uint16_t read_variable_length_one_byte_each(int socket, unsigned char *buf) {
     uint16_t length = 1;
-    read_from_socket(socket, buf, 1);
+    sst_read_from_socket(socket, buf, 1);
     if (buf[0] > 127) {
         return length + read_variable_length_one_byte_each(socket, buf + 1);
     } else {
@@ -105,7 +105,7 @@ int read_header_return_data_buf_pointer(int socket, unsigned char *message_type,
                                         unsigned int buf_length) {
     unsigned char received_buf[MAX_PAYLOAD_BUF_SIZE];
     // Read the first byte.
-    read_from_socket(socket, received_buf, MESSAGE_TYPE_SIZE);
+    sst_read_from_socket(socket, received_buf, MESSAGE_TYPE_SIZE);
     *message_type = received_buf[0];
     // Read one bytes each, until the variable length buffer ends.
     unsigned int var_length_buf_size = read_variable_length_one_byte_each(
@@ -121,7 +121,7 @@ int read_header_return_data_buf_pointer(int socket, unsigned char *message_type,
     if (ret_length > buf_length) {
         error_exit("Larger buffer size required.");
     }
-    unsigned int bytes_read = read_from_socket(socket, buf, buf_length);
+    unsigned int bytes_read = sst_read_from_socket(socket, buf, buf_length);
     if (ret_length != bytes_read) {
         error_exit("Wrong read... Exiting..");
     }
@@ -226,7 +226,7 @@ int mod(int a, int b) {
     return r < 0 ? r + b : r;
 }
 
-unsigned int read_from_socket(int socket, unsigned char *buf,
+unsigned int sst_read_from_socket(int socket, unsigned char *buf,
                               unsigned int buf_length) {
     if (socket < 0) {
         // Socket is not open.
@@ -242,7 +242,7 @@ unsigned int read_from_socket(int socket, unsigned char *buf,
     return (unsigned int)length_read;
 }
 
-unsigned int write_to_socket(int socket, const unsigned char *buf,
+unsigned int sst_write_to_socket(int socket, const unsigned char *buf,
                              unsigned int buf_length) {
     if (socket < 0) {
         // Socket is not open.

--- a/c_common.h
+++ b/c_common.h
@@ -233,7 +233,7 @@ int mod(int a, int b);
 // @param buf A pointer to the buffer where the data will be stored.
 // @param buf_length The maximum number of bytes to read into the buffer.
 // @return The number of bytes successfully read, or -1 if an error occurred.
-unsigned int read_from_socket(int socket, unsigned char *buf,
+unsigned int sst_read_from_socket(int socket, unsigned char *buf,
                               unsigned int buf_length);
 
 // Writes data to a socket from a buffer.
@@ -244,7 +244,7 @@ unsigned int read_from_socket(int socket, unsigned char *buf,
 // @param buf A pointer to the buffer containing the data to be written.
 // @param buf_length The number of bytes to write from the buffer.
 // @return The number of bytes successfully written, or -1 if an error occurred.
-unsigned int write_to_socket(int socket, const unsigned char *buf,
+unsigned int sst_write_to_socket(int socket, const unsigned char *buf,
                              unsigned int buf_length);
 
 // Checks message type if it is SECURE_COMM_MSG. This is needed as a separate

--- a/c_secure_comm.c
+++ b/c_secure_comm.c
@@ -226,7 +226,7 @@ void send_auth_request_message(unsigned char *serialized,
                             &message_length);
         }
         unsigned int bytes_written =
-            write_to_socket(sock, message, message_length);
+            sst_write_to_socket(sock, message, message_length);
         if (bytes_written != message_length) {
             error_exit("Failed to write data to socket.");
         }
@@ -246,7 +246,7 @@ void send_auth_request_message(unsigned char *serialized,
                             &message_length);
         }
         unsigned int bytes_written =
-            write_to_socket(sock, message, message_length);
+            sst_write_to_socket(sock, message, message_length);
         if (bytes_written != message_length) {
             error_exit("Failed to write data to socket.");
         }
@@ -420,7 +420,7 @@ int send_SECURE_COMM_message(char *msg, unsigned int msg_length,
                     sender_buf, &sender_buf_length);
 
     unsigned int bytes_written =
-        write_to_socket(session_ctx->sock, sender_buf, sender_buf_length);
+        sst_write_to_socket(session_ctx->sock, sender_buf, sender_buf_length);
     if (bytes_written != sender_buf_length) {
         error_exit("Failed to write data to socket.");
     }
@@ -524,7 +524,7 @@ session_key_list_t *send_session_key_req_via_TCP(SST_ctx_t *ctx) {
     while (state == INIT || state == AUTH_HELLO_RECEIVED) {
         unsigned char received_buf[MAX_AUTH_COMM_LENGTH];
         unsigned int received_buf_length =
-            read_from_socket(sock, received_buf, sizeof(received_buf));
+            sst_read_from_socket(sock, received_buf, sizeof(received_buf));
         unsigned char message_type;
         unsigned int data_buf_length;
         unsigned char *data_buf = parse_received_message(

--- a/ipfs.c
+++ b/ipfs.c
@@ -270,7 +270,7 @@ void receive_data_and_download_file(unsigned char *skey_id_in_str,
     write(sock, data, 2 + name_size);
     unsigned char received_buf[MAX_PAYLOAD_LENGTH];
     unsigned int received_buf_length =
-        read_from_socket(sock, received_buf, sizeof(received_buf));
+        sst_read_from_socket(sock, received_buf, sizeof(received_buf));
     printf("Receive the information for file.\n");
     gettimeofday(&filemanager_end, NULL);
     float filemanager_time =
@@ -323,7 +323,7 @@ void send_add_reader_req_via_TCP(SST_ctx_t *ctx, char *add_reader) {
     for (;;) {
         unsigned char received_buf[MAX_AUTH_COMM_LENGTH];
         unsigned int received_buf_length =
-            read_from_socket(sock, received_buf, sizeof(received_buf));
+            sst_read_from_socket(sock, received_buf, sizeof(received_buf));
         unsigned char message_type;
         unsigned int data_buf_length;
         unsigned char *data_buf = parse_received_message(


### PR DESCRIPTION
### Change name of read()/write() functions.
Changed name of `read_from_socket()` and `write_to_socket` to `sst_read_from_socket` and `sst_write_to_socket`, to prevent coincidentally getting same names of functions, causing errors.