### PR TITLE
Minor fix on checking session key

### DIFF
--- a/c_api.c
+++ b/c_api.c
@@ -158,6 +158,9 @@ session_key_t *get_session_key_by_ID(unsigned char *target_session_key_id,
     for (int i = 0; i < existing_s_key_list->num_key; i++) {
         session_key_found = check_session_key(target_session_key_id_int,
                                               existing_s_key_list, i);
+        if (session_key_found >= 0) {
+            break;  // Exit loop early when key is found
+        }
     }
     if (session_key_found >= 0) {
         s_key = &existing_s_key_list->s_key[session_key_found];

--- a/c_api.c
+++ b/c_api.c
@@ -151,20 +151,15 @@ session_key_t *get_session_key_by_ID(unsigned char *target_session_key_id,
 
     // If the entity_server already has the corresponding session key,
     // it does not have to request session key from Auth
-    int session_key_found = -1;
+    int session_key_idx = -1;
     if (existing_s_key_list == NULL) {
         SST_print_error_exit("Session key list must be not NULL.\n");
     }
-    for (int i = 0; i < existing_s_key_list->num_key; i++) {
-        session_key_found = check_session_key(target_session_key_id_int,
-                                              existing_s_key_list, i);
-        if (session_key_found >= 0) {
-            break;  // Exit loop early when key is found
-        }
-    }
-    if (session_key_found >= 0) {
-        s_key = &existing_s_key_list->s_key[session_key_found];
-    } else if (session_key_found == -1) {
+    session_key_idx = find_session_key(target_session_key_id_int,
+                                            existing_s_key_list);
+    if (session_key_idx >= 0) {
+        s_key = &existing_s_key_list->s_key[session_key_idx];
+    } else if (session_key_idx == -1) {
         // WARNING: The following line overwrites the purpose.
         snprintf(ctx->config->purpose[ctx->config->purpose_index],
             MAX_PURPOSE_LENGTH,

--- a/c_secure_comm.c
+++ b/c_secure_comm.c
@@ -700,17 +700,16 @@ unsigned char *check_handshake1_send_handshake2(
     return ret;
 }
 
-int check_session_key(unsigned int key_id, session_key_list_t *s_key_list,
-                      int idx) {
+int find_session_key(unsigned int key_id, session_key_list_t *s_key_list) {
     // TODO: Fix integer size 32 or 64
-    unsigned int list_key_id = read_unsigned_int_BE(
-        s_key_list->s_key[idx].key_id, SESSION_KEY_ID_SIZE);
-
-    if (key_id == list_key_id) {
-        return idx;
-    } else {
-        return -1;
+    for (int idx = 0; idx < s_key_list->num_key; idx++) {
+        unsigned int list_key_id = read_unsigned_int_BE(
+            s_key_list->s_key[idx].key_id, SESSION_KEY_ID_SIZE);
+        if (key_id == list_key_id) {
+            return idx;
+        }
     }
+    return -1;
 }
 
 void add_session_key_to_list(session_key_t *s_key,

--- a/c_secure_comm.h
+++ b/c_secure_comm.h
@@ -172,15 +172,12 @@ unsigned char *check_handshake1_send_handshake2(
     unsigned char *server_nonce, session_key_t *s_key,
     unsigned int *ret_length);
 
-// This function is used when checking if the server already has the session_key
-// requested Checks if the s_key_list's idx'th session_key_id equals with the
-// key_id
-// @param key_id the target key id to obtain
+// This function is used to find the session_key by its identifier (key_id)
+// in the given session key list and returns the index of the found key.
+// @param key_id the target key id to be found
 // @param s_key_list the cached session_key_list
-// @param idx current index
-// @return index of the s_key_list
-int check_session_key(unsigned int key_id, session_key_list_t *s_key_list,
-                      int idx);
+// @return index of the s_key_list if the key is found or -1 otherwise
+int find_session_key(unsigned int key_id, session_key_list_t *s_key_list);
 
 // Adds session key to the list.
 // Appends at the destination list's rear_idx.


### PR DESCRIPTION
This bug was found by @CarlosBeltranQ 

The `check_session_key` kept checking the session key list even if it found the key.

Add to break the for loop when the session key with the corresponding id is found.