### PR TITLE
Fix of vulnerabilities caused by sprintf by replacing it with snprintf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ entity_server
 /**/Makefile
 **/build/**
 **/Testing/**
+.vscode

--- a/c_api.c
+++ b/c_api.c
@@ -163,8 +163,9 @@ session_key_t *get_session_key_by_ID(unsigned char *target_session_key_id,
         s_key = &existing_s_key_list->s_key[session_key_found];
     } else if (session_key_found == -1) {
         // WARNING: The following line overwrites the purpose.
-        sprintf(ctx->config->purpose[ctx->config->purpose_index],
-                "{\"keyId\":%d}", target_session_key_id_int);
+        snprintf(ctx->config->purpose[ctx->config->purpose_index],
+            MAX_PURPOSE_LENGTH,
+            "{\"keyId\":%d}", target_session_key_id_int);
 
         session_key_list_t *s_key_list;
         s_key_list =

--- a/c_api.h
+++ b/c_api.h
@@ -47,10 +47,10 @@ typedef struct {
 } distribution_key_t;
 
 typedef struct {
-    char name[MAX_ENTITY_NAME_LENGTH];
+    char name[MAX_ENTITY_NAME_LENGTH + 1];
     // Currently, the config struct can hold up to two purposes.
     unsigned short purpose_index;
-    char purpose[2][MAX_PURPOSE_LENGTH];
+    char purpose[2][MAX_PURPOSE_LENGTH + 1];
     int numkey;
     AES_encryption_mode_t encryption_mode;
     hmac_mode_t hmac_mode;

--- a/examples/file_block_encrypt_example/block_common.h
+++ b/examples/file_block_encrypt_example/block_common.h
@@ -16,6 +16,8 @@
 #define TOTAL_BLOCK_NUM 10
 #define TOTAL_FILE_NUM 3
 
+#define BLOCK_FILE_NAME_MAX_LENGTH 15
+
 typedef struct {
     unsigned long int first_index;
     unsigned int length;

--- a/examples/file_block_encrypt_example/block_reader.c
+++ b/examples/file_block_encrypt_example/block_reader.c
@@ -31,9 +31,9 @@ int main(int argc, char *argv[]) {
         get_session_key_by_ID(encrypted_file_metadata[i].key_id, ctx,
                               s_key_list);
         char encrypted_filename[BLOCK_FILE_NAME_MAX_LENGTH + 1];
-        snprintf(encrypted_filename, sizeof(encrypted_filename) - 1, "encrypted%d.txt", i);
+        snprintf(encrypted_filename, BLOCK_FILE_NAME_MAX_LENGTH, "encrypted%d.txt", i);
         char plaintext_filename[BLOCK_FILE_NAME_MAX_LENGTH + 1];
-        snprintf(plaintext_filename, sizeof(plaintext_filename) - 1, "plaintext%d.txt", i);
+        snprintf(plaintext_filename, BLOCK_FILE_NAME_MAX_LENGTH, "plaintext%d.txt", i);
 
         FILE *encrypted_fp;
         FILE *plaintext_fp;

--- a/examples/file_block_encrypt_example/block_reader.c
+++ b/examples/file_block_encrypt_example/block_reader.c
@@ -30,10 +30,10 @@ int main(int argc, char *argv[]) {
         // s_key_list.
         get_session_key_by_ID(encrypted_file_metadata[i].key_id, ctx,
                               s_key_list);
-        char encrypted_filename[15];
-        sprintf(encrypted_filename, "encrypted%d.txt", i);
-        char plaintext_filename[15];
-        sprintf(plaintext_filename, "plaintext%d.txt", i);
+        char encrypted_filename[BLOCK_FILE_NAME_MAX_LENGTH + 1];
+        snprintf(encrypted_filename, sizeof(encrypted_filename) - 1, "encrypted%d.txt", i);
+        char plaintext_filename[BLOCK_FILE_NAME_MAX_LENGTH + 1];
+        snprintf(plaintext_filename, sizeof(plaintext_filename) - 1, "plaintext%d.txt", i);
 
         FILE *encrypted_fp;
         FILE *plaintext_fp;

--- a/examples/file_block_encrypt_example/block_reader_load_s_key_list.c
+++ b/examples/file_block_encrypt_example/block_reader_load_s_key_list.c
@@ -30,10 +30,10 @@ int main(int argc, char *argv[]) {
         // Request session key by session key ID. It will be added to the
         // s_key_list. get_session_key_by_ID(encrypted_file_metadata[i].key_id,
         // ctx, &s_key_list);
-        char encrypted_filename[15];
-        sprintf(encrypted_filename, "encrypted%d.txt", i);
-        char plaintext_filename[15];
-        sprintf(plaintext_filename, "plaintext%d.txt", i);
+        char encrypted_filename[BLOCK_FILE_NAME_MAX_LENGTH + 1];
+        sprintf(encrypted_filename, BLOCK_FILE_NAME_MAX_LENGTH, "encrypted%d.txt", i);
+        char plaintext_filename[BLOCK_FILE_NAME_MAX_LENGTH + 1];
+        snprintf(plaintext_filename, BLOCK_FILE_NAME_MAX_LENGTH, "plaintext%d.txt", i);
 
         FILE *encrypted_fp;
         FILE *plaintext_fp;

--- a/examples/file_block_encrypt_example/block_writer.c
+++ b/examples/file_block_encrypt_example/block_writer.c
@@ -32,10 +32,10 @@ int main(int argc, char *argv[]) {
 
         memcpy(encrypted_file_metadata[i].key_id, s_key_list->s_key[i].key_id,
                SESSION_KEY_ID_SIZE);
-        char encrypted_filename[15];
-        sprintf(encrypted_filename, "encrypted%d.txt", i);
-        char plaintext_filename[15];
-        sprintf(plaintext_filename, "plaintext%d.txt", i);
+        char encrypted_filename[BLOCK_FILE_NAME_MAX_LENGTH + 1];
+        snprintf(encrypted_filename, "encrypted%d.txt", BLOCK_FILE_NAME_MAX_LENGTH, i);
+        char plaintext_filename[BLOCK_FILE_NAME_MAX_LENGTH + 1];
+        snprintf(plaintext_filename, BLOCK_FILE_NAME_MAX_LENGTH, "plaintext%d.txt", i);
 
         FILE *encrypted_fp;
         FILE *plaintext_fp;

--- a/ipfs.c
+++ b/ipfs.c
@@ -48,8 +48,8 @@ void file_duplication_check(const char *file_name, const char *file_extension,
            strlen(file_extension));
     file_name_buf[strlen(file_name) + strlen(file_extension)] = '\0';
     for (;;) {
-        if (suffix_num == MAX_REPLY_NUM) {
-            SST_print_error("Cannot save the file. \n");
+        if (suffix_num >= MAX_REPLY_NUM) {
+            SST_print_error("Cannot save the file as file name's suffix number exceeds max.\n");
             exit(1);
         }
         if (0 == access(file_name_buf, F_OK)) {


### PR DESCRIPTION
This PR fixes security vulnerabilities caused by unprotected sprintf function calls, by replacing sprintf with snprintf. This PR also includes minor code improvements, including the use of constants instead of inline integer values.

These vulnerabilities are raised by SonarQube analysis as shown below.
![SST_sprintf](https://github.com/user-attachments/assets/127bf9a3-5f69-49ab-806e-9c17a5b4a853)
