### PR TITLE
Fix unused argc warning (-Werror) by checking argument count

### DIFF
--- a/examples/server_client_example/entity_client.c
+++ b/examples/server_client_example/entity_client.c
@@ -5,7 +5,15 @@
 
 #include "../../c_api.h"
 
+void exit_with_error(char *message) {
+    fputs(message, stderr);
+    fputc('\n', stderr);
+    exit(1);
+}
 int main(int argc, char *argv[]) {
+    if (argc != 2) {
+        exit_with_error("Enter config path (entity_client.c)");
+    }
     char *config_path = argv[1];
     SST_ctx_t *ctx = init_SST(config_path);
 

--- a/examples/server_client_example/entity_server.c
+++ b/examples/server_client_example/entity_server.c
@@ -15,7 +15,7 @@ void exit_with_error(char *message) {
 
 int main(int argc, char *argv[]) {
     if (argc != 2) {
-        exit_with_error("Enter config path");
+        exit_with_error("Enter config path (entity_server.c)");
     }
 
     int serv_sock, clnt_sock, clnt_sock2;

--- a/examples/server_client_example/threaded_get_target_id_client.c
+++ b/examples/server_client_example/threaded_get_target_id_client.c
@@ -8,8 +8,15 @@
  *
  */
 #include <stdio.h>
+#include <stdlib.h>
 
 #include "../../c_api.h"
+
+void exit_with_error(char *message) {
+    fputs(message, stderr);
+    fputc('\n', stderr);
+    exit(1);
+}
 
 void write_session_key_to_file(session_key_t *s_key, const char *file_path) {
     FILE *fp = fopen(file_path, "wb");
@@ -23,6 +30,9 @@ void write_session_key_to_file(session_key_t *s_key, const char *file_path) {
 }
 
 int main(int argc, char *argv[]) {
+    if (argc != 2) {
+    	exit_with_error("Enter config path (target_id_client.c)");
+    }
     char *config_path = argv[1];
     SST_ctx_t *ctx = init_SST(config_path);
 

--- a/examples/server_client_example/threaded_get_target_id_server.c
+++ b/examples/server_client_example/threaded_get_target_id_server.c
@@ -10,6 +10,7 @@
  */
 #include <pthread.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #include "../../c_api.h"
 
@@ -18,6 +19,12 @@ typedef struct {
     SST_ctx_t *ctx;
     char *file_path;
 } thread_args_t;
+
+void exit_with_error(char *message) {
+    fputs(message, stderr);
+    fputc('\n', stderr);
+    exit(1);
+}
 
 void *call_get_session_key_by_ID(void *args) {
     thread_args_t *data = (thread_args_t *)args;
@@ -55,6 +62,9 @@ void *call_get_session_key_by_ID(void *args) {
 }
 
 int main(int argc, char *argv[]) {
+    if (argc != 1) {
+        exit_with_error("Enter config path (target_id_server.c)");
+    }
     char *config_path = argv[1];
     SST_ctx_t *ctx = init_SST(config_path);
     pthread_mutex_init(&ctx->mutex, NULL);


### PR DESCRIPTION
added `void exit_with_error()` to all files that were affected by unused argc warning (`-Werror`) with name of source file for debugging.
`#include <stdlib.h>` in` files for `exit()` function in `void exit_with_error()`