### PR TITLE
Add prefix 'sst_' to 'read_from_socket' and 'write_to_socket' & Minor typo fixes.

### DIFF
--- a/c_api.c
+++ b/c_api.c
@@ -99,7 +99,8 @@ SST_session_ctx_t *secure_connect_to_server_with_socket(session_key_t *s_key,
     unsigned int sender_HS_1_length;
     make_sender_buf(parsed_buf, parsed_buf_length, SKEY_HANDSHAKE_1,
                     sender_HS_1, &sender_HS_1_length);
-    int bytes_written = write_to_socket(sock, sender_HS_1, sender_HS_1_length);
+    int bytes_written =
+        sst_write_to_socket(sock, sender_HS_1, sender_HS_1_length);
     if ((unsigned int)bytes_written != sender_HS_1_length) {
         SST_print_error_exit("Failed to write data to socket.");
     }
@@ -109,7 +110,7 @@ SST_session_ctx_t *secure_connect_to_server_with_socket(session_key_t *s_key,
     // received handshake 2
     unsigned char received_buf[MAX_HS_BUF_LENGTH];
     int received_buf_length =
-        read_from_socket(sock, received_buf, sizeof(received_buf));
+        sst_read_from_socket(sock, received_buf, sizeof(received_buf));
     if (received_buf_length < 0) {
         SST_print_error_exit(
             "Socket read eerror in secure_connect_to_server_with_socket()\n");
@@ -132,7 +133,7 @@ SST_session_ctx_t *secure_connect_to_server_with_socket(session_key_t *s_key,
         make_sender_buf(parsed_buf, parsed_buf_length, SKEY_HANDSHAKE_3,
                         sender_HS_2, &sender_HS_2_length);
         int bytes_written =
-            write_to_socket(sock, sender_HS_2, sender_HS_2_length);
+            sst_write_to_socket(sock, sender_HS_2, sender_HS_2_length);
         if ((unsigned int)bytes_written != sender_HS_2_length) {
             SST_print_error_exit("Failed to write data to socket.");
         }
@@ -202,7 +203,7 @@ SST_session_ctx_t *server_secure_comm_setup(
     if (entity_server_state == IDLE) {
         unsigned char received_buf[MAX_HS_BUF_LENGTH];
         int received_buf_length =
-            read_from_socket(clnt_sock, received_buf, HANDSHAKE_1_LENGTH);
+            sst_read_from_socket(clnt_sock, received_buf, HANDSHAKE_1_LENGTH);
         if (received_buf_length < 0) {
             SST_print_error_exit(
                 "Socket read eerror in server_secure_comm_setup()\n");
@@ -243,7 +244,7 @@ SST_session_ctx_t *server_secure_comm_setup(
             make_sender_buf(parsed_buf, parsed_buf_length, SKEY_HANDSHAKE_2,
                             sender, &sender_length);
             int bytes_written =
-                write_to_socket(clnt_sock, sender, sender_length);
+                sst_write_to_socket(clnt_sock, sender, sender_length);
             if ((unsigned int)bytes_written != sender_length) {
                 SST_print_error_exit("Failed to write data to socket.");
             }
@@ -255,7 +256,7 @@ SST_session_ctx_t *server_secure_comm_setup(
     if (entity_server_state == HANDSHAKE_2_SENT) {
         unsigned char received_buf[MAX_HS_BUF_LENGTH];
         int received_buf_length =
-            read_from_socket(clnt_sock, received_buf, HANDSHAKE_3_LENGTH);
+            sst_read_from_socket(clnt_sock, received_buf, HANDSHAKE_3_LENGTH);
         if (received_buf_length < 0) {
             SST_print_error_exit(
                 "Socket read eerror in server_secure_comm_setup()\n");
@@ -310,8 +311,8 @@ void *receive_thread(void *SST_session_ctx) {
     unsigned char received_buf[MAX_PAYLOAD_LENGTH];
     int received_buf_length;
     while (1) {
-        received_buf_length = read_from_socket(session_ctx->sock, received_buf,
-                                               sizeof(received_buf));
+        received_buf_length = sst_read_from_socket(
+            session_ctx->sock, received_buf, sizeof(received_buf));
         if (received_buf_length < 0) {
             SST_print_error_exit("Socket read eerror in receive_thread()\n");
         }

--- a/c_common.c
+++ b/c_common.c
@@ -157,7 +157,7 @@ unsigned char *parse_received_message(unsigned char *received_buf,
 
 uint16_t read_variable_length_one_byte_each(int socket, unsigned char *buf) {
     uint16_t length = 1;
-    int received_buf_length = read_from_socket(socket, buf, 1);
+    int received_buf_length = sst_read_from_socket(socket, buf, 1);
     if (received_buf_length < 0) {
         SST_print_error_exit(
             "Socket read eerror in read_variable_length_one_byte_each().\n");
@@ -175,7 +175,7 @@ int read_header_return_data_buf_pointer(int socket, unsigned char *message_type,
     unsigned char received_buf[MAX_PAYLOAD_BUF_SIZE];
     // Read the first byte.
     int received_buf_length =
-        read_from_socket(socket, received_buf, MESSAGE_TYPE_SIZE);
+        sst_read_from_socket(socket, received_buf, MESSAGE_TYPE_SIZE);
     if (received_buf_length < 0) {
         SST_print_error_exit(
             "Socket read eerror in read_header_return_data_buf_pointer().\n");
@@ -195,7 +195,7 @@ int read_header_return_data_buf_pointer(int socket, unsigned char *message_type,
     if (ret_length > buf_length) {
         SST_print_error_exit("Larger buffer size required.");
     }
-    int bytes_read = read_from_socket(socket, buf, buf_length);
+    int bytes_read = sst_read_from_socket(socket, buf, buf_length);
     if ((unsigned int)bytes_read != ret_length) {
         SST_print_error_exit("Wrong read... Exiting..");
     }
@@ -301,7 +301,8 @@ int mod(int a, int b) {
     return r < 0 ? r + b : r;
 }
 
-int read_from_socket(int socket, unsigned char *buf, unsigned int buf_length) {
+int sst_read_from_socket(int socket, unsigned char *buf,
+                         unsigned int buf_length) {
     if (socket < 0) {
         // Socket is not open.
         errno = EBADF;
@@ -316,8 +317,8 @@ int read_from_socket(int socket, unsigned char *buf, unsigned int buf_length) {
     return (unsigned int)length_read;
 }
 
-int write_to_socket(int socket, const unsigned char *buf,
-                    unsigned int buf_length) {
+int sst_write_to_socket(int socket, const unsigned char *buf,
+                        unsigned int buf_length) {
     if (socket < 0) {
         // Socket is not open.
         errno = EBADF;

--- a/c_common.h
+++ b/c_common.h
@@ -261,7 +261,8 @@ int mod(int a, int b);
 // @param buf A pointer to the buffer where the data will be stored.
 // @param buf_length The maximum number of bytes to read into the buffer.
 // @return The number of bytes successfully read, or -1 if an error occurred.
-int read_from_socket(int socket, unsigned char *buf, unsigned int buf_length);
+int sst_read_from_socket(int socket, unsigned char *buf,
+                         unsigned int buf_length);
 
 // Writes data to a socket from a buffer.
 // This function writes up to `buf_length` bytes from the provided buffer
@@ -271,8 +272,8 @@ int read_from_socket(int socket, unsigned char *buf, unsigned int buf_length);
 // @param buf A pointer to the buffer containing the data to be written.
 // @param buf_length The number of bytes to write from the buffer.
 // @return The number of bytes successfully written, or -1 if an error occurred.
-int write_to_socket(int socket, const unsigned char *buf,
-                    unsigned int buf_length);
+int sst_write_to_socket(int socket, const unsigned char *buf,
+                        unsigned int buf_length);
 
 // Checks message type if it is SECURE_COMM_MSG. This is needed as a separate
 // function not to define SECURE_COMM_MSG in c_api.h

--- a/c_secure_comm.c
+++ b/c_secure_comm.c
@@ -777,18 +777,18 @@ void update_validity(session_key_t *session_key) {
 }
 
 int check_session_key_list_addable(int requested_num_key,
-                                   session_key_list_t *s_ley_list) {
-    if (MAX_SESSION_KEY - s_ley_list->num_key < requested_num_key) {
+                                   session_key_list_t *s_key_list) {
+    if (MAX_SESSION_KEY - s_key_list->num_key < requested_num_key) {
         // Checks (num_key) number from the oldest session_keys.
         int ret = 1;
         int expired;
         int temp;
         for (int i = 0; i < requested_num_key; i++) {
-            temp = mod((i + s_ley_list->rear_idx - s_ley_list->num_key),
+            temp = mod((i + s_key_list->rear_idx - s_key_list->num_key),
                        MAX_SESSION_KEY);
-            expired = check_session_key_validity(&s_ley_list->s_key[temp]);
+            expired = check_session_key_validity(&s_key_list->s_key[temp]);
             if (expired) {
-                s_ley_list->num_key -= 1;
+                s_key_list->num_key -= 1;
             }
             ret = ret && expired;
         }

--- a/c_secure_comm.c
+++ b/c_secure_comm.c
@@ -506,7 +506,7 @@ session_key_list_t *send_session_key_request_check_protocol(
         if (s_key_list == NULL) {
             return NULL;
         }
-        SST_print_debug("Received %d keys.n", ctx->config->numkey);
+        SST_print_debug("Received %d keys.\n", ctx->config->numkey);
 
         // SecureCommServer.js handleSessionKeyResp
         //  if(){} //TODO: migration

--- a/c_secure_comm.c
+++ b/c_secure_comm.c
@@ -247,7 +247,7 @@ void send_auth_request_message(unsigned char *serialized,
             make_sender_buf(enc, enc_length, ADD_READER_REQ_IN_PUB_ENC, message,
                             &message_length);
         }
-        int bytes_written = write_to_socket(sock, message, message_length);
+        int bytes_written = sst_write_to_socket(sock, message, message_length);
         if ((unsigned int)bytes_written != message_length) {
             SST_print_error_exit("Failed to write data to socket.");
         }
@@ -267,7 +267,7 @@ void send_auth_request_message(unsigned char *serialized,
             make_sender_buf(enc, enc_length, ADD_READER_REQ, message,
                             &message_length);
         }
-        int bytes_written = write_to_socket(sock, message, message_length);
+        int bytes_written = sst_write_to_socket(sock, message, message_length);
         if ((unsigned int)bytes_written != message_length) {
             SST_print_error_exit("Failed to write data to socket.");
         }
@@ -445,7 +445,7 @@ int send_SECURE_COMM_message(char *msg, unsigned int msg_length,
                     sender_buf, &sender_buf_length);
 
     int bytes_written =
-        write_to_socket(session_ctx->sock, sender_buf, sender_buf_length);
+        sst_write_to_socket(session_ctx->sock, sender_buf, sender_buf_length);
     if ((unsigned int)bytes_written != sender_buf_length) {
         SST_print_error_exit("Failed to write data to socket.");
     }
@@ -549,7 +549,7 @@ session_key_list_t *send_session_key_req_via_TCP(SST_ctx_t *ctx) {
     while (state == INIT || state == AUTH_HELLO_RECEIVED) {
         unsigned char received_buf[MAX_AUTH_COMM_LENGTH];
         int received_buf_length =
-            read_from_socket(sock, received_buf, sizeof(received_buf));
+            sst_read_from_socket(sock, received_buf, sizeof(received_buf));
 
         if (received_buf_length < 0) {
             SST_print_error_exit(

--- a/ipfs.c
+++ b/ipfs.c
@@ -223,7 +223,7 @@ void upload_to_file_system_manager(session_key_t *s_key, SST_ctx_t *ctx,
     memcpy(data + 3 + name_size, s_key->key_id, key_id_size);
     data[3 + name_size + key_id_size] = hash_value_len;
     memcpy(data + 4 + name_size + key_id_size, hash_value, hash_value_len);
-    int bytes_written = write_to_socket(
+    int bytes_written = sst_write_to_socket(
         sock, data, 4 + name_size + key_id_size + hash_value_len);
     if (bytes_written != (4 + name_size + key_id_size + hash_value_len)) {
         SST_print_error_exit("Failed to write data to socket.");
@@ -284,13 +284,13 @@ void receive_data_and_download_file(unsigned char *skey_id_in_str,
     data[0] = DOWNLOAD_INDEX;
     data[1] = name_size;
     memcpy(data + 2, ctx->config->name, name_size);
-    int bytes_written = write_to_socket(sock, data, 2 + name_size);
+    int bytes_written = sst_write_to_socket(sock, data, 2 + name_size);
     if (bytes_written != (2 + name_size)) {
         SST_print_error_exit("Failed to write data to socket.");
     }
     unsigned char received_buf[MAX_PAYLOAD_LENGTH];
     int received_buf_length =
-        read_from_socket(sock, received_buf, sizeof(received_buf));
+        sst_read_from_socket(sock, received_buf, sizeof(received_buf));
     if (received_buf_length < 0) {
         SST_print_error_exit(
             "Socket read eerror in receive_data_and_download_file().\n");
@@ -347,7 +347,7 @@ void send_add_reader_req_via_TCP(SST_ctx_t *ctx, char *add_reader) {
     for (;;) {
         unsigned char received_buf[MAX_AUTH_COMM_LENGTH];
         int received_buf_length =
-            read_from_socket(sock, received_buf, sizeof(received_buf));
+            sst_read_from_socket(sock, received_buf, sizeof(received_buf));
         if (received_buf_length < 0) {
             SST_print_error_exit(
                 "Socket read eerror in send_add_reader_req_via_TCP().\n");


### PR DESCRIPTION
1. I changed the function names, adding a prefix `sst_`.
 - `read_from_socket` -> `sst_read_from_socket`
 - `write_to_socket` -> `sst_write_to_socket`

This is to avoid potential naming conflicts with existing third-party functions. 

2. I fixed some minor typos.