### PR TITLE
Fix `get_session_key()` failing when multiple threads request Auth at once.

### DIFF
--- a/tests/multi_thread_get_session_key_test.c
+++ b/tests/multi_thread_get_session_key_test.c
@@ -1,6 +1,6 @@
 /**
  * @file multi_thread_get_session_key_test.c
- * @author your name (you@domain.com)
+ * @author Dongha Kim
  * @brief Test get_session_key() in multiple threads.
  * This tests if get_session_key() can be called in multiple threads without
  * mutex locks. However, this test nondeterministically fails.


### PR DESCRIPTION
Closing this due to iotauth/iotauth#53 fixes this.