### PR TITLE
Fix format string mismatches in `SST_print_error` and enforce compile-time checks

### DIFF
--- a/src/c_api.h
+++ b/src/c_api.h
@@ -377,6 +377,6 @@ void SST_print_error(const char* fmt, ...) ATTRIBUTE_FORMAT_PRINTF(1, 2);
 // Uses printf-style formatting.
 // @param fmt Format string for the debug message.
 // @param ... Additional arguments for formatting.
-void SST_print_error_exit(const char* fmt, ...);
+void SST_print_error_exit(const char* fmt, ...) ATTRIBUTE_FORMAT_PRINTF(1, 2);
 
 #endif  // C_API_H

--- a/src/c_common.c
+++ b/src/c_common.c
@@ -310,13 +310,13 @@ int connect_as_client(const char* ip_addr, int port_num, int* sock) {
             continue;
         }
 
-        SST_print_error("Connection attempt %d failed: %s. Retrying...",
+        SST_print_error("Connection attempt %d failed. Retrying...",
                         count_retries);
 
         close(*sock);
         *sock = socket(AF_INET, SOCK_STREAM, 0);
         if (*sock == -1) {
-            SST_print_error("socket() error during retry: %s");
+            SST_print_error("socket() error during retry");
             ret = -1;
             break;
         }

--- a/src/c_common.h
+++ b/src/c_common.h
@@ -62,6 +62,9 @@ typedef struct {
 #define ATTRIBUTE_FORMAT_PRINTF(f, s)
 #endif
 
+void SST_print_error(const char* fmt, ...) ATTRIBUTE_FORMAT_PRINTF(1, 2);
+void SST_print_error_exit(const char* fmt, ...) ATTRIBUTE_FORMAT_PRINTF(1, 2);
+
 // Debug logging (only enabled in DEBUG mode)
 #ifdef DEBUG
 #define SST_DEBUG_ENABLED 1


### PR DESCRIPTION
This PR fixes the seg faults caused by `SST_print_error()`.

There was a mismatch in the number of parameters in the function.
However, the compiler didn't catch this because the functions use variadic arguments, so I added `ATTRIBUTE_FORMAT_PRINTF` to their declarations in the headers (`c_common.h` and `c_api.h`) as AI suggested.