### PR TITLE
update .gitigonre to track .DS_Store file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ entity_server
 .vscode
 !/Makefile
 embedded/receiver/config/*
+.DS_Store


### PR DESCRIPTION
Add .DS_Store file type to .gitignore for macs