### PR TITLE
Align memory management in `load_session_key_list_with_password` with `load_session_key_list`

### DIFF
--- a/src/c_api.c
+++ b/src/c_api.c
@@ -499,6 +499,10 @@ int save_session_key_list(session_key_list_t* session_key_list,
 
 int load_session_key_list(session_key_list_t* session_key_list,
                           const char* file_path) {
+    if (session_key_list == NULL || session_key_list->s_key == NULL) {
+        SST_print_error("session_key_list or session_key_list->s_key is NULL.");
+        return -1;
+    }
     FILE* load_file_fp;
     if ((load_file_fp = fopen(file_path, "rb")) == NULL) {
         SST_print_error("Failed to fopen()");
@@ -589,6 +593,10 @@ int load_session_key_list_with_password(session_key_list_t* session_key_list,
                                         unsigned int password_len,
                                         const char* salt,
                                         unsigned int salt_len) {
+    if (session_key_list == NULL || session_key_list->s_key == NULL) {
+        SST_print_error("session_key_list or session_key_list->s_key is NULL.");
+        return -1;
+    }
     unsigned char iv[AES_BLOCK_SIZE];
     unsigned char ciphertext[sizeof(session_key_list_t) +
                              sizeof(session_key_t) * MAX_SESSION_KEY];
@@ -636,13 +644,16 @@ int load_session_key_list_with_password(session_key_list_t* session_key_list,
         return -1;
     }
 
+    // Save the malloced pointer
+    session_key_t* s = session_key_list->s_key;
+
     // Deserialize the buffer into session_key_list
     memcpy(session_key_list, buffer, sizeof(session_key_list_t));
-    session_key_list->s_key = malloc(sizeof(session_key_t) * MAX_SESSION_KEY);
-    if (!session_key_list->s_key) {
-        SST_print_error("Memory allocation failed!");
-        return -1;
-    }
+
+    // Reload the saved pointer
+    session_key_list->s_key = s;
+
+    // Copy session keys into pre-allocated memory
     memcpy(session_key_list->s_key, buffer + sizeof(session_key_list_t),
            sizeof(session_key_t) * MAX_SESSION_KEY);
 


### PR DESCRIPTION
**Problem**: `load_session_key_list_with_password()` dynamically allocated memory (`malloc`) for `session_key_list->s_key` internally. This was inconsistent with `load_session_key_list()`, which expects the caller to pre-allocate the memory. As a result, loading into a pre-allocated structure (as in the integration test `save_load_session_key_list_with_password_test.c`) caused a memory leak.

**Solution**: Refactored `load_session_key_list_with_password()` to reuse the pre-allocated s_key pointer instead of calling `malloc`. Also added a NULL check at the beginning to prevent potential segmentation faults.

This bug was found while reviewing https://iotauth.github.io/docs/c-api-reference#load_session_key_list_with_password.