### PR TITLE
Fix SonarQube high severity issues on potential referencing of a null pointer and format check instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ c_common -> c_crypto -> c_secure_comm -> c_api -> entity_client, entity_server
 -   Returns struct session_key_list_t.
 
 **SST_session_ctx_t *secure_connect_to_server(session_key_t *s_key, SST_ctx_t *ctx)**
-
 -   `secure_connect_to_server()` is a function that establishes a secure connection with the entity server in the struct config.
 -   Input is the session key received from `get_session_key()` and struct config returned from `load_config()`.
 -   Returns struct SST_session_ctx_t
@@ -66,7 +65,6 @@ pthread_create(&thread, NULL, &receive_thread_read_one_each, (void \*)session_ct
 ```
 
 **int read_secure_message(unsigned char *buf, unsigned int buf_length, unsigned char *plaintext, SST_session_ctx_t *session_ctx)**
-
 - `read_secure_message` checks the message header if it is a `SECURE_COMM_MSG`, and fills the buffer with the received decrypted message.
 - Input is the pointer to the user-declared buffer, and the given buffer's length (not the received message).
 - Returns the length of the decrypted message.
@@ -148,4 +146,14 @@ To run examples, please check out the [`examples/`](./examples/README.md) direct
         4. Change from `"Visual Studio"` to `"{ BasedOnStyle: Google, IndentWidth: 4 }"`
     -   To format the code, follow the instructions on this [page](https://code.visualstudio.com/docs/editor/codebasics#_formatting).
 
-*Last updated on June 10, 2026*
+-   To format all C/C++ source files in the repository using the project's clang-format style, run:
+    ```
+    make format
+    ```
+-   To check formatting without modifying files (exits with an error if any file is not properly formatted), run:
+    ```
+    make format-check
+    ```
+    Both commands operate on all `.c`, `.h`, `.cpp`, `.hpp`, `.cc`, and `.hh` files, excluding the `build/` directory and `embedded/lib/`.
+
+*Last updated on June 12, 2026*

--- a/src/c_api.h
+++ b/src/c_api.h
@@ -355,6 +355,16 @@ int secure_rand(int min, int max);
 #define ATTRIBUTE_FORMAT_PRINTF(f, s)
 #endif
 
+#if defined(__GNUC__) || defined(__clang__)
+#define ATTRIBUTE_NORETURN __attribute__((noreturn))
+#elif defined(_MSC_VER)
+#define ATTRIBUTE_NORETURN __declspec(noreturn)
+#elif __STDC_VERSION__ >= 201112L
+#define ATTRIBUTE_NORETURN _Noreturn
+#else
+#define ATTRIBUTE_NORETURN
+#endif
+
 // Print out debug messages. This will be printed only when the
 // cmake -DCMAKE_BUILD_TYPE=DEBUG is on.
 // Uses printf-style formatting.
@@ -378,6 +388,7 @@ void SST_print_error(const char* fmt, ...) ATTRIBUTE_FORMAT_PRINTF(1, 2);
 // Uses printf-style formatting.
 // @param fmt Format string for the debug message.
 // @param ... Additional arguments for formatting.
-void SST_print_error_exit(const char* fmt, ...) ATTRIBUTE_FORMAT_PRINTF(1, 2);
+void SST_print_error_exit(const char* fmt, ...)
+    ATTRIBUTE_FORMAT_PRINTF(1, 2) ATTRIBUTE_NORETURN;
 
 #endif  // C_API_H

--- a/src/c_common.h
+++ b/src/c_common.h
@@ -62,9 +62,20 @@ typedef struct {
 #define ATTRIBUTE_FORMAT_PRINTF(f, s)
 #endif
 
+#if defined(__GNUC__) || defined(__clang__)
+#define ATTRIBUTE_NORETURN __attribute__((noreturn))
+#elif defined(_MSC_VER)
+#define ATTRIBUTE_NORETURN __declspec(noreturn)
+#elif __STDC_VERSION__ >= 201112L
+#define ATTRIBUTE_NORETURN _Noreturn
+#else
+#define ATTRIBUTE_NORETURN
+#endif
+
 void SST_print_warning(const char* fmt, ...) ATTRIBUTE_FORMAT_PRINTF(1, 2);
 void SST_print_error(const char* fmt, ...) ATTRIBUTE_FORMAT_PRINTF(1, 2);
-void SST_print_error_exit(const char* fmt, ...) ATTRIBUTE_FORMAT_PRINTF(1, 2);
+void SST_print_error_exit(const char* fmt, ...)
+    ATTRIBUTE_FORMAT_PRINTF(1, 2) ATTRIBUTE_NORETURN;
 
 // Debug logging (only enabled in DEBUG mode)
 #ifdef DEBUG

--- a/tests/multiple_request_get_session_key_test.c
+++ b/tests/multiple_request_get_session_key_test.c
@@ -33,33 +33,37 @@ int main(int argc, char* argv[]) {
     session_key_list_t* s_key_list = get_session_key(ctx, NULL);
     if (s_key_list == NULL) {
         SST_print_error_exit("Failed 1st get_session_key().");
+    } else {
+        printf("1st request succeeded. num_key: %d\n", s_key_list->num_key);
+        assert(s_key_list->num_key == EXPECTED_KEYS_1ST);
     }
-    printf("1st request succeeded. num_key: %d\n", s_key_list->num_key);
-    assert(s_key_list->num_key == EXPECTED_KEYS_1ST);
 
     // 2nd request: Append to session key list.
     s_key_list = get_session_key(ctx, s_key_list);
     if (s_key_list == NULL) {
         SST_print_error_exit("Failed 2nd get_session_key().");
+    } else {
+        printf("2nd request completed. num_key: %d\n", s_key_list->num_key);
+        assert(s_key_list->num_key == EXPECTED_KEYS_2ND);
     }
-    printf("2nd request completed. num_key: %d\n", s_key_list->num_key);
-    assert(s_key_list->num_key == EXPECTED_KEYS_2ND);
 
     // 3rd request: Append to session key list again.
     s_key_list = get_session_key(ctx, s_key_list);
     if (s_key_list == NULL) {
         SST_print_error_exit("Failed 3rd get_session_key().");
+    } else {
+        printf("3rd request completed. num_key: %d\n", s_key_list->num_key);
+        assert(s_key_list->num_key == EXPECTED_KEYS_3RD);
     }
-    printf("3rd request completed. num_key: %d\n", s_key_list->num_key);
-    assert(s_key_list->num_key == EXPECTED_KEYS_3RD);
 
     // 4th request: This should reach the limit and fail to add.
     s_key_list = get_session_key(ctx, s_key_list);
     if (s_key_list == NULL) {
         SST_print_error_exit("Failed 4th get_session_key().");
+    } else {
+        printf("4th request completed. num_key: %d\n", s_key_list->num_key);
+        assert(s_key_list->num_key == EXPECTED_KEYS_4TH);
     }
-    printf("4th request completed. num_key: %d\n", s_key_list->num_key);
-    assert(s_key_list->num_key == EXPECTED_KEYS_4TH);
 
     free_session_key_list_t(s_key_list);
     free_SST_ctx_t(ctx);

--- a/tests/multiple_request_get_session_key_test.c
+++ b/tests/multiple_request_get_session_key_test.c
@@ -33,37 +33,33 @@ int main(int argc, char* argv[]) {
     session_key_list_t* s_key_list = get_session_key(ctx, NULL);
     if (s_key_list == NULL) {
         SST_print_error_exit("Failed 1st get_session_key().");
-    } else {
-        printf("1st request succeeded. num_key: %d\n", s_key_list->num_key);
-        assert(s_key_list->num_key == EXPECTED_KEYS_1ST);
     }
+    printf("1st request succeeded. num_key: %d\n", s_key_list->num_key);
+    assert(s_key_list->num_key == EXPECTED_KEYS_1ST);
 
     // 2nd request: Append to session key list.
     s_key_list = get_session_key(ctx, s_key_list);
     if (s_key_list == NULL) {
         SST_print_error_exit("Failed 2nd get_session_key().");
-    } else {
-        printf("2nd request completed. num_key: %d\n", s_key_list->num_key);
-        assert(s_key_list->num_key == EXPECTED_KEYS_2ND);
     }
+    printf("2nd request completed. num_key: %d\n", s_key_list->num_key);
+    assert(s_key_list->num_key == EXPECTED_KEYS_2ND);
 
     // 3rd request: Append to session key list again.
     s_key_list = get_session_key(ctx, s_key_list);
     if (s_key_list == NULL) {
         SST_print_error_exit("Failed 3rd get_session_key().");
-    } else {
-        printf("3rd request completed. num_key: %d\n", s_key_list->num_key);
-        assert(s_key_list->num_key == EXPECTED_KEYS_3RD);
     }
+    printf("3rd request completed. num_key: %d\n", s_key_list->num_key);
+    assert(s_key_list->num_key == EXPECTED_KEYS_3RD);
 
     // 4th request: This should reach the limit and fail to add.
     s_key_list = get_session_key(ctx, s_key_list);
     if (s_key_list == NULL) {
         SST_print_error_exit("Failed 4th get_session_key().");
-    } else {
-        printf("4th request completed. num_key: %d\n", s_key_list->num_key);
-        assert(s_key_list->num_key == EXPECTED_KEYS_4TH);
     }
+    printf("4th request completed. num_key: %d\n", s_key_list->num_key);
+    assert(s_key_list->num_key == EXPECTED_KEYS_4TH);
 
     free_session_key_list_t(s_key_list);
     free_SST_ctx_t(ctx);


### PR DESCRIPTION
Fix SonarQube high-severity issues:
Access to field 'num_key' results in a dereference of a null pointer (loaded from variable 's_key_list')
Null pointers should not be dereferenced c:S2259

https://sonarcloud.io/project/issues?impactSeverities=HIGH&impactSoftwareQualities=RELIABILITY&severities=BLOCKER%2CCRITICAL%2CMAJOR%2CMINOR&sinceLeakPeriod=true&issueStatuses=OPEN%2CCONFIRMED&types=BUG&id=iotauth_sst-c-api

<img width="1215" height="749" alt="Screenshot 2026-06-12 at 1 04 19 PM" src="https://github.com/user-attachments/assets/3b80bc17-b96f-4201-91a0-319a2ecbf411" />
