### PR TITLE
Fix handling of connection closure with data buffer length of 0

### DIFF
--- a/src/c_api.c
+++ b/src/c_api.c
@@ -404,9 +404,6 @@ void* receive_thread_read_one_each(void* SST_session_ctx) {
             SST_print_error("Failed to read_secure_message().");
             return NULL;
         }
-        if (data_buf_length == 0) {
-            return NULL;
-        }
         SST_print_log("Received: %.*s", data_buf_length, data_buf);
     }
 }

--- a/src/c_api.c
+++ b/src/c_api.c
@@ -404,6 +404,9 @@ void* receive_thread_read_one_each(void* SST_session_ctx) {
             SST_print_error("Failed to read_secure_message().");
             return NULL;
         }
+        if (data_buf_length == 0) {
+            return NULL;
+        }
         SST_print_log("Received: %.*s", data_buf_length, data_buf);
     }
 }

--- a/src/c_common.c
+++ b/src/c_common.c
@@ -399,7 +399,7 @@ int sst_read_from_socket(int socket, unsigned char* buf,
     if (length_read < 0) {
         SST_print_error("Reading from socket %d failed.", socket);
     } else if (length_read == 0) {
-        SST_print_error("Connection closed from socket %d.", socket);
+        SST_print_debug("Connection closed from socket %d.", socket);
     }
     return length_read;
 }


### PR DESCRIPTION
This issue was discovered in https://github.com/iotauth/iotauth/pull/70.

The connection closure should not be treated as an error.

The error log in the CI test added by https://github.com/iotauth/iotauth/pull/70 is as follows:
[server] ERROR: Connection closed from socket 5.