### PR TITLE
Add `get_session_key_with_index` to support multi-purpose entities

### DIFF
--- a/examples/ipfs_examples/c/entity_downloader.c
+++ b/examples/ipfs_examples/c/entity_downloader.c
@@ -15,7 +15,6 @@ int main(int argc, char* argv[]) {
         SST_print_error_exit("init_SST() failed.");
     }
     session_key_list_t* s_key_list = init_empty_session_key_list();
-    ctx->config.purpose_index = 0;
     char file_name[BUFF_SIZE];
     unsigned char received_skey_id[SESSION_KEY_ID_SIZE];
     estimate_time_t estimate_time[5];

--- a/examples/ipfs_examples/c/entity_uploader.c
+++ b/examples/ipfs_examples/c/entity_uploader.c
@@ -32,13 +32,12 @@ int main(int argc, char* argv[]) {
     }
     fclose(add_reader_file);
     // Set purpose to make session key request for file sharing.
-    ctx->config.purpose_index = 1;
     estimate_time_t estimate_time[5];
     struct timeval keygen_start, keygen_end;
     gettimeofday(&keygen_start, NULL);
-    session_key_list_t* s_key_list_0 = get_session_key(ctx, NULL);
+    session_key_list_t* s_key_list_0 = get_session_key_with_index(ctx, 1, NULL);
     if (s_key_list_0 == NULL) {
-        SST_print_error_exit("Failed get_session_key().");
+        SST_print_error_exit("Failed get_session_key_with_index().");
     }
     gettimeofday(&keygen_end, NULL);
     float keygen_time = keygen_end.tv_sec - keygen_start.tv_sec;

--- a/examples/ipfs_examples/c/secure_entity_downloader.c
+++ b/examples/ipfs_examples/c/secure_entity_downloader.c
@@ -17,10 +17,9 @@ int main(int argc, char* argv[]) {
         SST_print_error_exit("init_SST() failed.");
     }
     session_key_list_t* s_key_list = init_empty_session_key_list();
-    ctx->config.purpose_index = 0;
-    session_key_list_t* s_key_list_0 = get_session_key(ctx, NULL);
+    session_key_list_t* s_key_list_0 = get_session_key_with_index(ctx, 0, NULL);
     if (s_key_list_0 == NULL) {
-        SST_print_error_exit("Failed get_session_key().");
+        SST_print_error_exit("Failed get_session_key_with_index().");
     }
     SST_session_ctx_t* session_ctx =
         secure_connect_to_server(&s_key_list_0->s_key[0], ctx);

--- a/examples/ipfs_examples/c/secure_entity_uploader.c
+++ b/examples/ipfs_examples/c/secure_entity_uploader.c
@@ -47,7 +47,8 @@ int main(int argc, char* argv[]) {
     if (hash_value_len < 0) {
         SST_print_error_exit("Failed file_encrypt_upload()");
     }
-    unsigned int test_key_id = convert_skid_buf_to_int(s_key_list_0->s_key[0].key_id, SESSION_KEY_ID_SIZE);
+    unsigned int test_key_id = convert_skid_buf_to_int(
+        s_key_list_0->s_key[0].key_id, SESSION_KEY_ID_SIZE);
     printf("DEBUG: FileSharing session key ID to upload: %u\n", test_key_id);
     char concat_buffer[MAX_PAYLOAD_LENGTH];
     int concat_buffer_size =

--- a/examples/ipfs_examples/c/secure_entity_uploader.c
+++ b/examples/ipfs_examples/c/secure_entity_uploader.c
@@ -34,10 +34,9 @@ int main(int argc, char* argv[]) {
     fclose(add_reader_file);
 
     // Set purpose to make session key request for file sharing.
-    ctx->config.purpose_index = 1;
-    session_key_list_t* s_key_list_0 = get_session_key(ctx, NULL);
+    session_key_list_t* s_key_list_0 = get_session_key_with_index(ctx, 1, NULL);
     if (s_key_list_0 == NULL) {
-        SST_print_error_exit("Failed get_session_key().");
+        SST_print_error_exit("Failed get_session_key_with_index().");
     }
     unsigned char hash_value[BUFF_SIZE];
     int hash_value_len;
@@ -48,14 +47,15 @@ int main(int argc, char* argv[]) {
     if (hash_value_len < 0) {
         SST_print_error_exit("Failed file_encrypt_upload()");
     }
+    unsigned int test_key_id = convert_skid_buf_to_int(s_key_list_0->s_key[0].key_id, SESSION_KEY_ID_SIZE);
+    printf("DEBUG: FileSharing session key ID to upload: %u\n", test_key_id);
     char concat_buffer[MAX_PAYLOAD_LENGTH];
     int concat_buffer_size =
         make_upload_req_buffer(&s_key_list_0->s_key[0], ctx, &hash_value[0],
                                hash_value_len, &concat_buffer[0]);
-    ctx->config.purpose_index = 0;
-    session_key_list_t* s_key_list = get_session_key(ctx, NULL);
+    session_key_list_t* s_key_list = get_session_key_with_index(ctx, 0, NULL);
     if (s_key_list == NULL) {
-        SST_print_error_exit("Failed get_session_key().");
+        SST_print_error_exit("Failed get_session_key_with_index().");
     }
     SST_session_ctx_t* session_ctx =
         secure_connect_to_server(&s_key_list->s_key[0], ctx);

--- a/examples/ipfs_examples/cpp/downloader.cpp
+++ b/examples/ipfs_examples/cpp/downloader.cpp
@@ -53,7 +53,6 @@ int main(int argc, char* argv[]) {
         SST_print_error_exit("init_SST() failed.");
     }
     session_key_list_t* s_key_list = init_empty_session_key_list();
-    ctx->config.purpose_index = 0;
     std::vector<char> file_name(BUFF_SIZE);
     std::vector<unsigned char> received_skey_id(SESSION_KEY_ID_SIZE);
     estimate_time_t estimate_time[5];

--- a/examples/ipfs_examples/cpp/uploader.cpp
+++ b/examples/ipfs_examples/cpp/uploader.cpp
@@ -45,9 +45,8 @@ int main(int argc, char* argv[]) {
     add_reader_file.close();
 
     // Set purpose to make session key request for file sharing.
-    ctx->config.purpose_index = 1;
     estimate_time_t estimate_time[5];
-    session_key_list_t* s_key_list_0 = get_session_key(ctx, NULL);
+    session_key_list_t* s_key_list_0 = get_session_key_with_index(ctx, 1, NULL);
     if (s_key_list_0 == NULL) {
         std::cerr << "Failed to get session key. Returning NULL." << std::endl;
         return EXIT_FAILURE;

--- a/src/c_api.c
+++ b/src/c_api.c
@@ -72,8 +72,12 @@ session_key_list_t* init_empty_session_key_list(void) {
     return session_key_list;
 }
 
-session_key_list_t* get_session_key(SST_ctx_t* ctx,
-                                    session_key_list_t* existing_s_key_list) {
+session_key_list_t* get_session_key_with_index(
+    SST_ctx_t* ctx, int purpose_index,
+    session_key_list_t* existing_s_key_list) {
+    snprintf(ctx->purpose_for_requesting_key,
+             sizeof(ctx->purpose_for_requesting_key), "%s",
+             ctx->config.purpose[purpose_index]);
     if (existing_s_key_list != NULL) {
         if (check_session_key_list_addable(ctx->config.numkey,
                                            existing_s_key_list) == 0) {
@@ -100,6 +104,12 @@ session_key_list_t* get_session_key(SST_ctx_t* ctx,
         free_session_key_list_t(earned_s_key_list);
         return existing_s_key_list;
     }
+}
+
+session_key_list_t* get_session_key(SST_ctx_t* ctx,
+                                    session_key_list_t* existing_s_key_list) {
+    return get_session_key_with_index(ctx, ctx->config.purpose_index,
+                                      existing_s_key_list);
 }
 
 SST_session_ctx_t* secure_connect_to_server(session_key_t* s_key,
@@ -232,13 +242,10 @@ session_key_t* get_session_key_by_ID(unsigned char* target_session_key_id,
             return NULL;
         }
 
-        if (strcmp(ctx->config.purpose[ctx->config.purpose_index],
-                   "{\"group\":\"Federates\"}") == 0) {
-            // Restore the original purpose after the key has been fetched.
-            snprintf(ctx->purpose_for_requesting_key,
-                     sizeof(ctx->purpose_for_requesting_key), "%s",
-                     ctx->config.purpose[ctx->config.purpose_index]);
-        }
+        // Restore the original purpose after the key has been fetched.
+        snprintf(ctx->purpose_for_requesting_key,
+                 sizeof(ctx->purpose_for_requesting_key), "%s",
+                 ctx->config.purpose[ctx->config.purpose_index]);
 
         int index =
             add_session_key_to_list(s_key_list->s_key, existing_s_key_list);

--- a/src/c_api.h
+++ b/src/c_api.h
@@ -136,6 +136,10 @@ session_key_list_t* init_empty_session_key_list(void);
 session_key_list_t* get_session_key(SST_ctx_t* ctx,
                                     session_key_list_t* existing_s_key_list);
 
+session_key_list_t* get_session_key_with_index(
+    SST_ctx_t* ctx, int purpose_index,
+    session_key_list_t* existing_s_key_list);
+
 // Connect to entity_server using the session key. This function can be called
 // after the connect() function, and uses the user's socket.
 // @param s_key session key struct received by Auth

--- a/src/c_api.h
+++ b/src/c_api.h
@@ -137,8 +137,7 @@ session_key_list_t* get_session_key(SST_ctx_t* ctx,
                                     session_key_list_t* existing_s_key_list);
 
 session_key_list_t* get_session_key_with_index(
-    SST_ctx_t* ctx, int purpose_index,
-    session_key_list_t* existing_s_key_list);
+    SST_ctx_t* ctx, int purpose_index, session_key_list_t* existing_s_key_list);
 
 // Connect to entity_server using the session key. This function can be called
 // after the connect() function, and uses the user's socket.


### PR DESCRIPTION
This PR introduces the `get_session_key_with_index()` API to support entities configured with multiple purposes.

### The Problem
Previously, the C API only provided `get_session_key()`, which always requested session keys using the first purpose (index 0) from the configuration. 
For complex setups (such as the IPFS file-sharing example) where an entity requires multiple session keys for different purposes (e.g., index 0 for secure communication with the File System Manager, and index 1 for file sharing), there was no clean API to request keys for subsequent purposes. Developers had to manually modify the internal configuration field (`ctx->config.purpose_index`), which is error-prone and breaks encapsulation.
Also, #65 introduced a bug found in #69 in the CI, and this PR fixes it.
BTW, the infinite hanging is fixed in iotauth/iotauth#74.

### The Solution
We introduce `get_session_key_with_index(ctx, purpose_index, existing_s_key_list)`:
- Allows requesting session keys by explicitly specifying a 0-based `purpose_index`.
- Maintains backwards-compatibility: `get_session_key()` remains unchanged and defaults to the first purpose (index 0).
- Updated C/C++ examples and API reference documentation to guide users towards this clean, index-based session key request mechanism.