### PR TITLE
Run `iotauth` integration tests as part of `sst-c-api` CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,11 @@ env:
   BUILD_TYPE: Release
 
 jobs:
+  iotauth-integration-test:
+    uses: iotauth/iotauth/.github/workflows/integration-test.yml@main
+    with:
+      sst-c-api-ref: ${{ github.sha }}
+
   Unit-Test:
     name: Unit Test
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        repository: iotauth/sst-c-api
     - name: Install openssl
       run: sudo apt-get update && sudo apt-get install -y openssl
 
@@ -56,8 +58,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - name: Check out sst-c-api
+      if: ${{ inputs.iotauth-ref == '' }}
+      uses: actions/checkout@v4
+      with:
+        repository: iotauth/sst-c-api
     - name: Read branch name from iotauth-ref.txt
+      if: ${{ inputs.iotauth-ref == '' }}
       id: read_ref
       run: |
         ref=$(head -n 1 iotauth-ref.txt)


### PR DESCRIPTION
Pull in iotauth's entity integration tests so changes to sst-c-api are validated against the full C/Node.js client-server matrix.

- Adds iotauth-integration-test job that calls iotauth's reusable workflow
- Passes current sst-c-api SHA so iotauth tests run against the triggering commit instead of the submodule-pinned version

Should be merged with https://github.com/iotauth/iotauth/pull/79