### PR TITLE
Ci fix: Fix reusable workflow loops, checkout refs, and workspace cleaning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   iotauth-integration-test:
     if: github.event_name != 'workflow_call'
-    uses: iotauth/iotauth/.github/workflows/integration-test.yml@main
+    uses: iotauth/iotauth/.github/workflows/integration-test.yml@ci-fix
     with:
       sst-c-api-ref: ${{ github.sha }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
         repository: iotauth/sst-c-api
         path: entity/c
         ref: ${{ github.event.pull_request.head.sha || github.sha }}
+        clean: false
     - name: Install openssl
       run: sudo apt-get update && sudo apt-get install -y openssl
     - name: Set up JDK 17

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   iotauth-integration-test:
     if: ${{ inputs.iotauth-ref == '' }}
-    uses: iotauth/iotauth/.github/workflows/integration-test.yml@ci-fix
+    uses: iotauth/iotauth/.github/workflows/integration-test.yml@main
     with:
       sst-c-api-ref: ${{ github.sha }}
 
@@ -85,7 +85,6 @@ jobs:
         repository: iotauth/sst-c-api
         path: entity/c
         ref: ${{ github.event.pull_request.head.sha || github.sha }}
-        clean: false
     - name: Install openssl
       run: sudo apt-get update && sudo apt-get install -y openssl
     - name: Set up JDK 17

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   iotauth-integration-test:
     if: ${{ inputs.iotauth-ref == '' }}
-    uses: iotauth/iotauth/.github/workflows/integration-test.yml@ci-fix
+    uses: iotauth/iotauth/.github/workflows/integration-test.yml@main
     with:
       sst-c-api-ref: ${{ github.sha }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   iotauth-integration-test:
     if: ${{ inputs.iotauth-ref == '' }}
-    uses: iotauth/iotauth/.github/workflows/integration-test.yml@main
+    uses: iotauth/iotauth/.github/workflows/integration-test.yml@ci-fix
     with:
       sst-c-api-ref: ${{ github.sha }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   iotauth-integration-test:
-    if: github.event_name != 'workflow_call'
+    if: ${{ inputs.iotauth-ref == '' }}
     uses: iotauth/iotauth/.github/workflows/integration-test.yml@ci-fix
     with:
       sst-c-api-ref: ${{ github.sha }}
@@ -36,7 +36,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         repository: iotauth/sst-c-api
-        ref: ${{ github.event_name == 'workflow_call' && 'main' || (github.event.pull_request.head.sha || github.sha) }}
+        ref: ${{ inputs.iotauth-ref != '' && 'main' || (github.event.pull_request.head.sha || github.sha) }}
     - name: Install openssl
       run: sudo apt-get update && sudo apt-get install -y openssl
 
@@ -79,7 +79,7 @@ jobs:
         submodules: true
         ref: ${{ inputs.iotauth-ref || steps.read_ref.outputs.ref }}
     - name: Check out specific ref of sst-c-api
-      if: ${{ github.event_name != 'workflow_call' }}
+      if: ${{ inputs.iotauth-ref == '' }}
       uses: actions/checkout@v4
       with:
         repository: iotauth/sst-c-api

--- a/iotauth-ref.txt
+++ b/iotauth-ref.txt
@@ -1,1 +1,1 @@
-ci-fix
+main

--- a/iotauth-ref.txt
+++ b/iotauth-ref.txt
@@ -1,1 +1,1 @@
-main
+ci-fix


### PR DESCRIPTION
This PR resolves critical issues in the CI workflow when called as a reusable workflow from `iotauth`:

- **Avoid infinite loop triggers**: Replaced `github.event_name` checks with `inputs.iotauth-ref` checks. (Since `github.event_name` inherits the caller's event name like `push`, the old condition did not prevent recursive calling).
- **Correct checkout refs**: Fixed checkout failures in called runs by ensuring `Unit-Test` checks out the correct `sst-c-api` ref instead of using the caller's (`iotauth`) commit SHA.
